### PR TITLE
pin previously unpinned versions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for Geo-Coder-OpenCage
 
 unreleased
+        dependencies:
+        - bump HTTP::Tiny to 0.83 (shipped with Perl 5.38), pin previously unpinned versions
+        - move Scalar::Util to RuntimeRequires (was misclassified as test-only)
+        - drop Pod::Perldoc from RuntimeRequires (not actually used)
         tests:
         - no longer test against Perl < 5.38
         - connectivity check uses TCP/443 (requires no root)

--- a/dist.ini
+++ b/dist.ini
@@ -6,23 +6,23 @@ license          = Perl_5
 copyright_holder = OpenCage GmbH
 
 [Prereqs / RuntimeRequires]
-Carp             = 0
-Cpanel::JSON::XS = >= 4.21 ;
-HTTP::Tiny       = 0
+Carp             = >= 1.54 ;
+Cpanel::JSON::XS = >= 4.40 ;
+HTTP::Tiny       = >= 0.083 ;
 IO::Socket::SSL  = >= 2.068 ;
 JSON::MaybeXS    = 1.004003
-Pod::Perldoc     = >= 3.21 ;
-URI              = 0
+Scalar::Util     = >= 1.63 ;
+URI              = >= 5.19 ;
 
 [Prereqs / TestRequires]
 LWP::Protocol::https = 6.10
 LWP::UserAgent  = 6.55
+Mozilla::CA     = >= 20240313 ;
 Net::Ping       = 2.73
-Scalar::Util    = 0
 Test::Exception = 0.32
 Test::More      = 0.92
 Test::Pod       = 1.51
-Test::Warn      = 0
+Test::Warn      = 0.37
 
 [GatherDir]
 


### PR DESCRIPTION
Bump dependency versions to what shipped with Perl 5.38 (July 2023)

`HTTP::Tiny` prior to version 0.83 didn't verify SSL certificate by default. -- thank you @byteoverride