### PR TITLE
document -http- parameter, make sure http=0 doesnt set it

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ unreleased
         - valid_params list wasn't actually used
         - valid_params warned if a parameter value was 0 (e.g. 'no_dedupe' can be set to 0)
         - 'key' can only be set in new(), not overwritten in geocoding calls
+        - fix defined() parenthesization in http=>1 handling
+        documentation:
+        - document http=>1 and ua=>$ua parameters of new()
         - We documented user-agent string as "Geo::Coder::OpenCage/$VERSION" but in code it
            used space as delimiter. It's also set when another UA is supplied in new() as
            documented.

--- a/lib/Geo/Coder/OpenCage.pm
+++ b/lib/Geo/Coder/OpenCage.pm
@@ -25,8 +25,8 @@ sub new {
     $ua->agent($ua_string);
     my $api_url = 'https://api.opencagedata.com/geocode/v1/json';
     
-    if (defined($params{http} && $params{http} == 1 )){
-        $api_url =~ s|^https|http|;
+    if (defined($params{http}) && $params{http} == 1){
+        $api_url =~ s|^https://|http://|;
     }
     my $self = {
         version => $version,
@@ -184,7 +184,26 @@ which includes a reference file for developing in Perl using this module.
 
 Get your API key from L<https://opencagedata.com>.
 
-Optionally "http => 1" can also be specified in which case API requests will NOT be made via https.
+=head3 Optional parameters
+
+=over
+
+=item C<< http => 1 >>
+
+Make API requests over plain HTTP instead of HTTPS.
+
+B<Warning:> this is strongly discouraged. Your API key and all queries (which
+may include user-supplied addresses or coordinates) will be transmitted in
+cleartext and visible to any network observer. Only use this if you have a
+specific reason to disable TLS (e.g. debugging via a local proxy).
+
+=item C<< ua => $user_agent >>
+
+Supply your own UserAgent object instead of the default L<HTTP::Tiny>. Useful
+for things like rate limiting (L<LWP::UserAgent::Throttled>) or testing with
+a mock UA. See L</ua> for details on the User-Agent header.
+
+=back
 
 =head2 ua
 


### PR DESCRIPTION
Setting `http => 0` would've enabled the feature. Bracket was in the wrong spot. -- thank you @byteoverride